### PR TITLE
Hide overlay from Recents

### DIFF
--- a/NotificationPeekPort/src/main/AndroidManifest.xml
+++ b/NotificationPeekPort/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
 
         <activity android:name=".peek.NotificationPeek$NotificationPeekActivity"
                   android:theme="@android:style/Theme.Holo.NoActionBar.Fullscreen"
-                  android:configChanges="orientation|keyboard"/>
+                  android:configChanges="orientation|keyboard"
+                  android:excludeFromRecents="true"/>
 
         <activity
                 android:name="com.reindeercrafts.notificationpeek.MainActivity"


### PR DESCRIPTION
NotificationPeek should not be shown in recents if we did not open the settings
